### PR TITLE
Install Terraform in the deploy workflow

### DIFF
--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -34,6 +34,11 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
       - name: Initialize Terraform
         run: |
           cd terraform


### PR DESCRIPTION
GitHub's ubuntu-24.04 runner images no longer ship Terraform, so the deploy failed with 'terraform: command not found'. Install it with hashicorp/setup-terraform. The wrapper is disabled because the cache invalidation step captures 'terraform output -raw' via command substitution, and the wrapper pollutes stdout.